### PR TITLE
commas as decimal separators make the soft crash

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -1,4 +1,4 @@
-﻿using LiveSplit.ComponentUtil;
+using LiveSplit.ComponentUtil;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -409,7 +409,6 @@ namespace alyx_multiplayer
         {
             _watchers.UpdateAll(game);
 
-            System.Globalization.CultureInfo invariantCulture = System.Globalization.CultureInfo.InvariantCulture;
             // Original code for local coords fetch
             // IntPtr localPtr = GetEntPtrFromIndex(1);
 
@@ -418,13 +417,15 @@ namespace alyx_multiplayer
             Vector3f localPos = GetEntPosFromPtr(localPtr);
             Vector3f localAng = GetEntAngleFromPtr(localPtr);
 
-            networkHandler.SendCoords(localPos.X.ToString(invariantCulture) + " " + localPos.Y.ToString(invariantCulture) + " " + localPos.Z.ToString(invariantCulture) 
-                                      + "_" + localAng.X.ToString(invariantCulture) + " " + localAng.Y.ToString(invariantCulture) + " " + localAng.Z.ToString(invariantCulture) + " ");
+            System.Globalization.CultureInfo invariantCulture = System.Globalization.CultureInfo.InvariantCulture;
+
+            networkHandler.SendCoords(localPos.X.ToString(invariantCulture) + " " + localPos.Y.ToString(invariantCulture) + " " + localPos.Z.ToString(invariantCulture) + "," +
+                                      localAng.X.ToString(invariantCulture) + " " + localAng.Y.ToString(invariantCulture) + " " + localAng.Z.ToString(invariantCulture) + " ");
 
             string[] unparsedCoords;
             try
             {
-                unparsedCoords = networkHandler.GetCoords().Split('_');
+                unparsedCoords = networkHandler.GetCoords().Split(',');
             } catch (NullReferenceException)
             {
                 unparsedCoords = new string[] { "0 0 0", "0 0 0" };

--- a/Core.cs
+++ b/Core.cs
@@ -417,7 +417,8 @@ namespace alyx_multiplayer
             Vector3f localPos = GetEntPosFromPtr(localPtr);
             Vector3f localAng = GetEntAngleFromPtr(localPtr);
 
-            networkHandler.SendCoords(localPos.ToString() + "," + localAng.ToString() + " ");
+            networkHandler.SendCoords(localPos.IX.ToString() + " " + localPos.IY.ToString() + " "+ localPos.IZ.ToString() + "," +
+                                      localAng.IX.ToString() + " " + localAng.IY.ToString() + " " + localAng.IZ.ToString() + " ");
 
             string[] unparsedCoords;
             try

--- a/Core.cs
+++ b/Core.cs
@@ -409,6 +409,7 @@ namespace alyx_multiplayer
         {
             _watchers.UpdateAll(game);
 
+            System.Globalization.CultureInfo invariantCulture = System.Globalization.CultureInfo.InvariantCulture;
             // Original code for local coords fetch
             // IntPtr localPtr = GetEntPtrFromIndex(1);
 
@@ -417,13 +418,13 @@ namespace alyx_multiplayer
             Vector3f localPos = GetEntPosFromPtr(localPtr);
             Vector3f localAng = GetEntAngleFromPtr(localPtr);
 
-            networkHandler.SendCoords(localPos.IX.ToString() + " " + localPos.IY.ToString() + " "+ localPos.IZ.ToString() + "," +
-                                      localAng.IX.ToString() + " " + localAng.IY.ToString() + " " + localAng.IZ.ToString() + " ");
+            networkHandler.SendCoords(localPos.X.ToString(invariantCulture) + " " + localPos.Y.ToString(invariantCulture) + " " + localPos.Z.ToString(invariantCulture) 
+                                      + "_" + localAng.X.ToString(invariantCulture) + " " + localAng.Y.ToString(invariantCulture) + " " + localAng.Z.ToString(invariantCulture) + " ");
 
             string[] unparsedCoords;
             try
             {
-                unparsedCoords = networkHandler.GetCoords().Split(',');
+                unparsedCoords = networkHandler.GetCoords().Split('_');
             } catch (NullReferenceException)
             {
                 unparsedCoords = new string[] { "0 0 0", "0 0 0" };
@@ -431,7 +432,7 @@ namespace alyx_multiplayer
             
             string[] unparsedPos = unparsedCoords[0].Split(' ');
             string[] unparsedAng = unparsedCoords[1].Split(' ');
-            System.Globalization.CultureInfo invariantCulture = System.Globalization.CultureInfo.InvariantCulture;
+
             Vector3f networkPos = new Vector3f(float.Parse(unparsedPos[0], invariantCulture), float.Parse(unparsedPos[1], invariantCulture), float.Parse(unparsedPos[2], invariantCulture));
             Vector3f networkAng = new Vector3f(float.Parse(unparsedAng[0], invariantCulture), float.Parse(unparsedAng[1], invariantCulture), float.Parse(unparsedAng[2], invariantCulture));
 

--- a/LuaUtils.cs
+++ b/LuaUtils.cs
@@ -33,7 +33,7 @@ namespace alyx_multiplayer
                 string AngXstr = ang.X.ToString(invariantCulture);
                 string AngYstr = ang.Y.ToString(invariantCulture);
                 string AngZstr = ang.Z.ToString(invariantCulture);
-                string AngVectorStr = PosXstr + "," + PosYstr + "," + PosZstr;
+                string AngVectorStr = AngXstr + "," + AngYstr + "," + AngZstr;
 
                 System.IO.File.WriteAllText(scriptPath + avatarScriptName, "Entities:FindByName(nil, \"" + entPrefix + avatarEntityName + "\"):SetOrigin(Vector(" + PosVectorStr + "));\n" +
                 "Entities:FindByName(nil, \"" + entPrefix + avatarEntityName + "\"):SetAngles(" + AngVectorStr + ")" );

--- a/LuaUtils.cs
+++ b/LuaUtils.cs
@@ -1,4 +1,4 @@
-﻿using LiveSplit.ComponentUtil;
+using LiveSplit.ComponentUtil;
 
 namespace alyx_multiplayer
 {
@@ -20,12 +20,23 @@ namespace alyx_multiplayer
         /// <param name="ang">Angle of the avatar.</param>
         public static void WriteCoordsToScript(string scriptPath, string entPrefix, Vector3f pos, Vector3f ang)
         {
+            System.Globalization.CultureInfo invariantCulture = new System.Globalization.CultureInfo("en-US");
             if (scriptPath.EndsWith("\\")) scriptPath.TrimEnd();
 
             try
             {
-                System.IO.File.WriteAllText(scriptPath + avatarScriptName, "Entities:FindByName(nil, \"" + entPrefix + avatarEntityName + "\"):SetOrigin(Vector(" + pos.X + "," + pos.Y + "," + (pos.Z + zOffset) + "));\n" +
-                "Entities:FindByName(nil, \"" + entPrefix + avatarEntityName + "\"):SetAngles(" + ang.X + "," + ang.Y + "," + ang.Z + ")");
+                string PosXstr = pos.X.ToString(invariantCulture);
+                string PosYstr = pos.Y.ToString(invariantCulture);
+                string PosZstr = (pos.Z+zOffset).ToString(invariantCulture);
+                string PosVectorStr = PosXstr + "," + PosYstr + "," + PosZstr;
+
+                string AngXstr = ang.X.ToString(invariantCulture);
+                string AngYstr = ang.Y.ToString(invariantCulture);
+                string AngZstr = ang.Z.ToString(invariantCulture);
+                string AngVectorStr = PosXstr + "," + PosYstr + "," + PosZstr;
+
+                System.IO.File.WriteAllText(scriptPath + avatarScriptName, "Entities:FindByName(nil, \"" + entPrefix + avatarEntityName + "\"):SetOrigin(Vector(" + PosVectorStr + "));\n" +
+                "Entities:FindByName(nil, \"" + entPrefix + avatarEntityName + "\"):SetAngles(" + AngVectorStr + ")" );
             } catch
             {
                 // That's fine, the file is being accessed by HL:A right now. Would normally throw System.IO.IOException.


### PR DESCRIPTION

*EDIT: Using int was too sloppy so I found a culture-invariat way to solve this bug (see second commit)*

So, this bug might be related to the fact that I am using a french computer,
the ToString() function was using commas as decimal separator, which therefore made the lines 426 create a string[6] instead of a string[2].
due to that the lines 432 and 433 did not work properly, and in the end the unparsedPos was just a string[1] which made the soft crash at line 435.
I fixed this by using the IX, IY and IZ values of the Vector3f, therefore using ints and avoiding decimal separators completely